### PR TITLE
feat(page, context): history panel has been added to calculator UI, functions to read and write and clear history added to context

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client"
 
 import { CalculatorProvider, useCalculator } from "./context/CalculatorContext";
 import CalculatorButton from "./components/CalculatorButton";
@@ -66,19 +66,64 @@ function Keypad() {
 }
 
 function Calculator() {
-	return (
-		<div className="mx-auto w-full max-w-xs sm:max-w-sm">
-			<div className="bg-black text-white rounded-3xl p-5 shadow-xl border border-neutral-800">
-				<Display />
-				<Keypad />
-			</div>
-		</div>
-	);
+    return (
+        <div className="mx-auto w-full max-w-xl grid gap-4 sm:grid-cols-2">
+            <div className="bg-black text-white rounded-3xl p-5 shadow-xl border border-neutral-800">
+                <Display />
+                <Keypad />
+            </div>
+            <HistoryPanel />
+        </div>
+    );
+}
+
+function HistoryPanel() {
+    const { history, clearHistory, setExpression, evaluateNow } = useCalculator();
+
+    return (
+        <div className="rounded-3xl p-5 shadow-xl border border-neutral-800 bg-neutral-950 text-white">
+            <div className="flex items-center justify-between mb-3">
+                <h2 className="text-lg font-semibold">History</h2>
+                <button
+                    className="text-sm px-3 py-1 rounded-full bg-neutral-700 hover:bg-neutral-600"
+                    onClick={clearHistory}
+                    aria-label="Clear history"
+                >
+                    Clear
+                </button>
+            </div>
+            {history.length === 0 ? (
+                <p className="text-neutral-400 text-sm">No history yet.</p>
+            ) : (
+                <ul className="space-y-2 max-h-80 overflow-auto pr-1">
+                    {history.map((h) => (
+                        <li key={h.id}>
+                            <button
+                                className="w-full text-left px-3 py-2 rounded-lg bg-neutral-900 hover:bg-neutral-800"
+                                onClick={() => {
+                                    setExpression(h.expression);
+                                    // Optionally re-evaluate to update the display
+                                    setTimeout(() => evaluateNow(), 0);
+                                }}
+                                aria-label={`Use ${h.expression} equals ${h.result}`}
+                            >
+                                <div className="text-neutral-300 text-sm">{h.expression}</div>
+                                <div className="text-white text-lg">= {h.result}</div>
+                                <div className="text-neutral-500 text-xs mt-1">
+                                    {new Date(h.ts).toLocaleString()}
+                                </div>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
 }
 
 export default function Home() {
 	return (
-		<div className="min-h-dvh w-full flex items-center justify-center bg-neutral-900 p-4">
+		<div className="min-h-dvh w-full flex items-center justify-center bg-neutral-950 p-4">
 			<CalculatorProvider>
 				<Calculator />
 			</CalculatorProvider>


### PR DESCRIPTION
**Summary**
- Add calculator history with persistent storage and a UI panel.
- Persist entries in browser localStorage and expose them via context.
- Allow reusing a past expression and clearing all history.

**Key Changes**
- Track history entries { id, expression, result, ts } in context.
- Load history on mount; save on change using localStorage.
- On successful evaluation (“=”), prepend a history entry.
- Expose history and clearHistory() through the provider.
- Add a History panel in the main page: view, reuse, and clear entries.

**UI/UX**
- Two-column layout on larger screens: calculator + history side-by-side.
- History item shows expression, result, and timestamp.
- Clicking a history item restores the expression and re-evaluates it.
- “Clear” button to remove all history entries.
